### PR TITLE
Remove unnecessary returns

### DIFF
--- a/spinlock.zig
+++ b/spinlock.zig
@@ -18,8 +18,8 @@ pub const Spinlock = struct {
 
     pub fn tryLock(self: *Self) bool {
         return switch (self.value.swap(.Locked, .acquire)) {
-            .Locked => return false,
-            .Unlocked => return true,
+            .Locked => false,
+            .Unlocked => true,
         };
     }
 


### PR DESCRIPTION
They technically don't hurt, but this way control flow is not messed up in that there are returns never run.